### PR TITLE
Update cpuminer-opt from 25.6 to 26.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,8 +26,8 @@ docker run --rm cniweb/cpuminer-opt:test cpuminer --cputest
 
 ### Versioning
 
-- Two-component versioning: 25.6 (no patch number)
-- Default VERSION_TAG=v25.6 (Dockerfile) / version="25.6" (build.sh)
+- Two-component versioning: 26.1 (no patch number)
+- Default VERSION_TAG=v26.1 (Dockerfile) / version="26.1" (build.sh)
 - Version bumps across: Dockerfile, build.sh, README.md, CHANGELOG.md
 
 ## Environment Variables

--- a/.github/prompts/create-release.prompt.md
+++ b/.github/prompts/create-release.prompt.md
@@ -7,7 +7,7 @@ Create a release for this repository.
 
 ## Workflow
 
-1. **Version input.** If no version is provided in the request, ask for it (format `25.6` or `v25.6`).
+1. **Version input.** If no version is provided in the request, ask for it (format `26.1` or `v26.1`).
 2. **Normalize** to `VERSION` (without `v`) and `TAG` (`v${VERSION}`).
 3. **Fetch upstream cpuminer-opt release notes** from `https://github.com/JayDDee/cpuminer-opt/releases/tag/v${VERSION}` using `gh release view v${VERSION} --repo JayDDee/cpuminer-opt --json body -q .body`. Extract the changelog items (bug fixes, features, improvements) — ignore SHA256 checksums and GPG signatures.
 4. **Update `CHANGELOG.md`**: add a new section at the top (below the header) with:

--- a/.github/workflows/release-from-version.yml
+++ b/.github/workflows/release-from-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "cpuminer-opt version (e.g. 25.6 or v25.6)"
+        description: "cpuminer-opt version (e.g. 26.1 or v26.1)"
         required: true
         type: string
 
@@ -30,10 +30,10 @@ jobs:
           VERSION="${INPUT#v}"
           TAG="v${VERSION}"
 
-          # cpuminer-opt uses two-component versioning (e.g. 25.6)
+          # cpuminer-opt uses two-component versioning (e.g. 26.1)
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version: $INPUT"
-            echo "Use two-component version format like 25.6 or v25.6"
+            echo "Use two-component version format like 26.1 or v26.1"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,11 @@ Primary instruction source: `.github/copilot-instructions.md` (canonical when it
 
 ## Release/versioning
 
-- cpuminer-opt uses two-component versioning (e.g. `25.6` — no patch number).
+- cpuminer-opt uses two-component versioning (e.g. `26.1` — no patch number).
 - Version bumps must stay synchronized across all four files: `Dockerfile`, `build.sh`, `README.md`, and `CHANGELOG.md`.
 - The release workflow (`.github/workflows/release-from-version.yml`) handles all four automatically: it updates version refs, and promotes `CHANGELOG.md`'s `## [Unreleased]` heading to `## [<version>] - <date>`. **The workflow fails fast if `CHANGELOG.md` has no `## [Unreleased]` section** — add one with the release notes before triggering it.
 - Prefer that workflow for releases: it updates version refs, commits, tags `vX.Y`, and creates the GitHub release.
-- The `Dockerfile` uses `ARG VERSION_TAG=v$version` (with `v` prefix), while `build.sh` uses `version="25.6"` (without `v` prefix).
+- The `Dockerfile` uses `ARG VERSION_TAG=v$version` (with `v` prefix), while `build.sh` uses `version="26.1"` (without `v` prefix).
 
 ## Small gotchas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,17 @@ Each entry tracks the upstream [cpuminer-opt](https://github.com/JayDDee/cpumine
 - Added pull request template.
 - `build.sh` now supports `build-only` argument (build without registry login/push).
 
+## [26.1] - 2026-07-30
+
+### Changed
+- Updated cpuminer-opt from 25.6 to 26.1
+
 ## [25.6] - 2025-01-14
 
 ### Packaging
 - Initial release packaging cpuminer-opt v25.6.
 - Dockerfile builds from source via git clone with AVX2/VAES optimizations.
 - Multi-registry push support (Docker Hub, GHCR, Quay.io).
+
+[26.1]: https://github.com/JayDDee/cpuminer-opt/releases/tag/v26.1
+[25.6]: https://github.com/JayDDee/cpuminer-opt/releases/tag/v25.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 
 # Set non-root user early
-ARG VERSION_TAG=v25.6
+ARG VERSION_TAG=v26.1
 ARG CPUMINER_USER=cpuminer
 ARG CPUMINER_UID=1000
 ARG CPUMINER_GID=1000
@@ -45,7 +45,7 @@ RUN set -eu; \
     && cd /tmp/cpuminer \
     && git checkout "$VERSION_TAG" \
     && ./autogen.sh \
-    && extracflags="$extracflags -Ofast -flto -fuse-linker-plugin -ftree-loop-if-convert-stores" \
+    && extracflags="-Ofast -flto -fuse-linker-plugin -ftree-loop-if-convert-stores" \
     && CFLAGS="-O3 -march=native -Wall" ./configure --with-curl \
     && make install -j 4 \
     && cd / \

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Define image name, version and registries
 image="cpuminer-opt"
-version="25.6"
+version="26.1"
 declare -a available_registries=()
 
 # Support build-only mode (used by CI validate job)


### PR DESCRIPTION
**Änderungen:**
- Dockerfile: `ARG VERSION_TAG=v25.6` → `v26.1`
- build.sh: `version="25.6"` → `"26.1"`
- Alle Dokumentationsdateien synchronisiert
- Fix: `extracflags` unset-variable Bug (verursacht Build-Bruch mit `set -eu`)

**Verifikation:** `docker build` erfolgreich, `--version` zeigt `cpuminer-opt 26.1`